### PR TITLE
feat: implement #10 — Agent observability: runtime telemetry pipeline so non-human agents can watch the simulation

### DIFF
--- a/api/telemetry.ts
+++ b/api/telemetry.ts
@@ -1,0 +1,63 @@
+```typescript
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { createClient } from '@vercel/kv';
+
+/**
+ * POST /api/telemetry
+ *
+ * Receives a TelemetrySnapshot JSON body from the browser simulation and
+ * stores it in Vercel KV.  Returns the list key so callers can reference it.
+ *
+ * Storage layout in KV:
+ *   crucible:telemetry:snapshots  — Redis LIST (newest first, capped at 100)
+ *   crucible:telemetry:latest     — STRING  (JSON of most-recent snapshot, for quick reads)
+ */
+
+const MAX_STORED_SNAPSHOTS = 100;
+const LIST_KEY = 'crucible:telemetry:snapshots';
+const LATEST_KEY = 'crucible:telemetry:latest';
+
+const kv = createClient({
+  url: process.env.KV_REST_API_URL ?? '',
+  token: process.env.KV_REST_API_TOKEN ?? '',
+});
+
+export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  let body: unknown;
+  try {
+    body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+  } catch {
+    res.status(400).json({ error: 'Invalid JSON body' });
+    return;
+  }
+
+  if (!body || typeof body !== 'object') {
+    res.status(400).json({ error: 'Body must be a JSON object' });
+    return;
+  }
+
+  const snapshot = body as Record<string, unknown>;
+
+  // Basic shape validation — we don't want garbage in KV
+  if (typeof snapshot['timestamp'] !== 'number' || typeof snapshot['simTime'] !== 'number') {
+    res.status(400).json({ error: 'Snapshot missing required fields: timestamp, simTime' });
+    return;
+  }
+
+  const serialized = JSON.stringify(snapshot);
+
+  // Prepend to the list (LPUSH) then trim to cap at MAX_STORED_SNAPSHOTS
+  await kv.lpush(LIST_KEY, serialized);
+  await kv.ltrim(LIST_KEY, 0, MAX_STORED_SNAPSHOTS - 1);
+
+  // Keep a quick-access "latest" key
+  await kv.set(LATEST_KEY, serialized);
+
+  res.status(200).json({ ok: true, stored: LIST_KEY });
+}
+```

--- a/orchestrator/implement-pr-body.md
+++ b/orchestrator/implement-pr-body.md
@@ -1,0 +1,31 @@
+## Summary
+
+- Adds a lightweight telemetry pipeline that captures evolutionary trajectory metrics every 60 seconds and routes them back to the governance system so agents can observe simulation outcomes when evaluating proposals.
+- Implements exactly the four O(n)/O(nk) metrics agreed in consensus: rolling genome centroid distance (diversity), birth/death ratio trend over 500 frames, diversity rate of change, and spatial grid entropy — no O(n²) pairwise diff, no continuous `toDataURL`.
+- Canvas snapshots are only taken when an anomaly fires (>2σ deviation from rolling baseline), keeping the GPU readback off the render hot-path.
+- Agent prompts receive delta-formatted summaries (`current`, `Δ last 5`, `Δ last 20`, `trend`) rather than raw snapshots, so agents reason about trajectory not instantaneous state. Storage uses Vercel KV (not Gist) to avoid race conditions with concurrent tabs.
+
+## Changes
+
+**`src/world/World.ts`**
+Adds `TelemetryTracker` (ring-buffer birth/death counts, rolling diversity history, per-metric anomaly baseline) and `World.captureSnapshot()` — the four consensus metrics plus population basics and anomaly flags. Also records births and deaths inline in `update()` via `telemetry.recordBirth()` / `recordDeath()`, and updates the rolling diversity history each frame using `_computeGenomeDiversity()` (O(nk), fixed feature vector capped at 7 nodes).
+
+**`src/main.ts`**
+Adds a 60-second `setInterval` that calls `captureAndPost()`. Anomaly detection is done by inspecting the preliminary snapshot; `toDataURL` is only called if anomalies are present or a force-capture is requested. Posts JSON to `/api/telemetry` as fire-and-forget.
+
+**`api/telemetry.ts`** *(new)*
+Vercel serverless endpoint. Receives snapshot JSON, validates required fields, prepends to a capped Redis LIST in Vercel KV (`crucible:telemetry:snapshots`, max 100 entries), and writes a quick-read `crucible:telemetry:latest` key. Returns `200 { ok: true }`.
+
+**`orchestrator/src/telemetry.ts`** *(new)*
+Client-side helper for the orchestrator. `fetchRecentSnapshots(n)` reads from Vercel KV. `buildSummary()` computes per-metric `{current, delta5, delta20, trend}` structs and de-duplicates recent anomaly flags. `formatForPrompt()` renders a Markdown table with delta-first formatting. `buildTelemetryPromptSection()` is the single export for dispatch.ts to call — it fetches, summarises, and formats in one step, returning an empty stub if no data is available yet.
+
+## Test plan
+- [ ] Run `npm run dev` and verify the simulation starts without errors
+- [ ] Open the browser console and confirm no errors appear at startup
+- [ ] Wait 60 seconds and verify `[telemetry]` log entries appear (or a `Failed to post` warning if KV is unconfigured — both are acceptable)
+- [ ] Trigger a fast population crash (open console, `sim.world.agents.forEach(a => a.dead = true)`) and confirm an anomaly snapshot is logged within the next telemetry cycle
+- [ ] Verify the canvas JPEG is only attached when anomalies are present (check the JSON body in the network tab)
+- [ ] With `KV_REST_API_URL` and `KV_REST_API_TOKEN` set, hit `POST /api/telemetry` with a valid snapshot body and confirm `200 { ok: true }`
+- [ ] Call `buildTelemetryPromptSection()` from the orchestrator context and confirm it returns a Markdown table with delta columns
+
+Closes #10

--- a/orchestrator/src/telemetry.ts
+++ b/orchestrator/src/telemetry.ts
@@ -1,0 +1,248 @@
+```typescript
+/**
+ * telemetry.ts — Fetches recent simulation snapshots from Vercel KV and
+ * formats them as a `## Current simulation state` section for agent prompts.
+ *
+ * This module is imported by dispatch.ts (or equivalent) immediately before
+ * building any agent prompt, so agents always reason from observed reality.
+ */
+
+import { createClient } from '@vercel/kv';
+
+// ── KV client ─────────────────────────────────────────────────────────────────
+
+const kv = createClient({
+  url: process.env.KV_REST_API_URL ?? '',
+  token: process.env.KV_REST_API_TOKEN ?? '',
+});
+
+const LIST_KEY = 'crucible:telemetry:snapshots';
+
+// ── Types (mirrored from src/world/World.ts — keep in sync) ──────────────────
+
+interface AnomalyFlag {
+  metric: string;
+  description: string;
+  value: number;
+  baseline: number;
+  sigmas: number;
+}
+
+interface TelemetrySnapshot {
+  timestamp: number;
+  simTime: number;
+  stepCount: number;
+  genomeDiversity: number;
+  birthRate: number;
+  deathRate: number;
+  birthDeathRatio: number;
+  diversityDelta: number;
+  spatialEntropy: number;
+  agentCount: number;
+  meanEnergy: number;
+  stddevEnergy: number;
+  anomalies: AnomalyFlag[];
+  canvasSnapshot?: string;
+}
+
+// ── Derived summary types ─────────────────────────────────────────────────────
+
+interface MetricSummary {
+  current: number;
+  /** Change from 5 snapshots ago (undefined if fewer snapshots exist) */
+  delta5: number | undefined;
+  /** Change from 20 snapshots ago (undefined if fewer snapshots exist) */
+  delta20: number | undefined;
+  /** Direction label inferred from delta5 */
+  trend: 'rising' | 'falling' | 'stable';
+}
+
+export interface SimulationStateSummary {
+  asOf: string;           // human-readable timestamp
+  snapshotCount: number;
+  agentCount: MetricSummary;
+  genomeDiversity: MetricSummary;
+  birthDeathRatio: MetricSummary;
+  spatialEntropy: MetricSummary;
+  recentAnomalies: AnomalyFlag[];
+}
+
+// ── Fetch and parse snapshots from KV ────────────────────────────────────────
+
+/**
+ * Fetch the last `n` snapshots from KV (newest first).
+ * Returns an empty array on any failure — callers should tolerate no-data.
+ */
+export async function fetchRecentSnapshots(n: number = 20): Promise<TelemetrySnapshot[]> {
+  try {
+    const raw = await kv.lrange(LIST_KEY, 0, n - 1);
+    return raw
+      .map(item => {
+        try {
+          return JSON.parse(item as string) as TelemetrySnapshot;
+        } catch {
+          return null;
+        }
+      })
+      .filter((s): s is TelemetrySnapshot => s !== null);
+  } catch (err) {
+    console.warn('[telemetry] Failed to fetch snapshots from KV:', err);
+    return [];
+  }
+}
+
+// ── Build summary ─────────────────────────────────────────────────────────────
+
+function trendLabel(delta: number | undefined): 'rising' | 'falling' | 'stable' {
+  if (delta === undefined || Math.abs(delta) < 1e-6) return 'stable';
+  return delta > 0 ? 'rising' : 'falling';
+}
+
+function metricSummary(
+  snapshots: TelemetrySnapshot[],
+  key: keyof Pick<
+    TelemetrySnapshot,
+    'agentCount' | 'genomeDiversity' | 'birthDeathRatio' | 'spatialEntropy'
+  >,
+): MetricSummary {
+  const current = snapshots[0]?.[key] as number ?? 0;
+  const at5  = snapshots[4]?.[key] as number | undefined;
+  const at20 = snapshots[19]?.[key] as number | undefined;
+  const delta5  = at5  !== undefined ? current - at5  : undefined;
+  const delta20 = at20 !== undefined ? current - at20 : undefined;
+  return { current, delta5, delta20, trend: trendLabel(delta5) };
+}
+
+/**
+ * Build a structured summary from the last `n` snapshots.
+ * Snapshots are expected newest-first (as stored by LPUSH).
+ */
+export function buildSummary(snapshots: TelemetrySnapshot[]): SimulationStateSummary {
+  const latest = snapshots[0];
+  const asOf = latest
+    ? new Date(latest.timestamp).toISOString()
+    : 'no data';
+
+  // Collect all anomalies from the most recent 5 snapshots, deduplicated by metric
+  const seenMetrics = new Set<string>();
+  const recentAnomalies: AnomalyFlag[] = [];
+  for (const snap of snapshots.slice(0, 5)) {
+    for (const flag of snap.anomalies) {
+      if (!seenMetrics.has(flag.metric)) {
+        seenMetrics.add(flag.metric);
+        recentAnomalies.push(flag);
+      }
+    }
+  }
+
+  return {
+    asOf,
+    snapshotCount: snapshots.length,
+    agentCount:      metricSummary(snapshots, 'agentCount'),
+    genomeDiversity: metricSummary(snapshots, 'genomeDiversity'),
+    birthDeathRatio: metricSummary(snapshots, 'birthDeathRatio'),
+    spatialEntropy:  metricSummary(snapshots, 'spatialEntropy'),
+    recentAnomalies,
+  };
+}
+
+// ── Format for agent prompt ───────────────────────────────────────────────────
+
+function fmt(value: number, precision: number = 2): string {
+  return value.toFixed(precision);
+}
+
+function fmtDelta(delta: number | undefined, precision: number = 2): string {
+  if (delta === undefined) return 'n/a';
+  const sign = delta >= 0 ? '+' : '';
+  return `${sign}${delta.toFixed(precision)}`;
+}
+
+/**
+ * Render the summary as a Markdown section suitable for prepending to an
+ * agent prompt.  Uses delta-first formatting so agents reason about trajectory,
+ * not current state.
+ *
+ * Example output:
+ * ```
+ * ## Current simulation state
+ * _As of 2025-01-15T12:34:56.000Z — based on 17 snapshots_
+ *
+ * | Metric | Current | Δ last 5 snapshots | Δ last 20 snapshots | Trend |
+ * ...
+ * ```
+ */
+export function formatForPrompt(summary: SimulationStateSummary): string {
+  const rows = [
+    [
+      'Agent count',
+      fmt(summary.agentCount.current, 0),
+      fmtDelta(summary.agentCount.delta5, 0),
+      fmtDelta(summary.agentCount.delta20, 0),
+      summary.agentCount.trend,
+    ],
+    [
+      'Genome diversity',
+      fmt(summary.genomeDiversity.current),
+      fmtDelta(summary.genomeDiversity.delta5),
+      fmtDelta(summary.genomeDiversity.delta20),
+      summary.genomeDiversity.trend,
+    ],
+    [
+      'Birth/death ratio',
+      fmt(summary.birthDeathRatio.current),
+      fmtDelta(summary.birthDeathRatio.delta5),
+      fmtDelta(summary.birthDeathRatio.delta20),
+      summary.birthDeathRatio.trend,
+    ],
+    [
+      'Spatial entropy',
+      fmt(summary.spatialEntropy.current),
+      fmtDelta(summary.spatialEntropy.delta5),
+      fmtDelta(summary.spatialEntropy.delta20),
+      summary.spatialEntropy.trend,
+    ],
+  ];
+
+  const header = '| Metric | Current | Δ last 5 snapshots | Δ last 20 snapshots | Trend |';
+  const divider = '|--------|---------|---------------------|----------------------|-------|';
+  const tableRows = rows
+    .map(([name, cur, d5, d20, trend]) => `| ${name} | ${cur} | ${d5} | ${d20} | ${trend} |`)
+    .join('\n');
+
+  let anomalySection = '';
+  if (summary.recentAnomalies.length > 0) {
+    const flags = summary.recentAnomalies
+      .map(a => `- **${a.metric}**: ${a.description} (current: ${fmt(a.value)}, baseline: ${fmt(a.baseline)})`)
+      .join('\n');
+    anomalySection = `\n\n### ⚠️ Recent anomalies\n${flags}`;
+  }
+
+  return [
+    '## Current simulation state',
+    `_As of ${summary.asOf} — based on ${summary.snapshotCount} snapshot(s)_`,
+    '',
+    header,
+    divider,
+    tableRows,
+    anomalySection,
+  ].join('\n');
+}
+
+// ── Main export: fetch + format in one call ───────────────────────────────────
+
+/**
+ * Convenience function: fetch recent snapshots and return a formatted Markdown
+ * block ready to prepend to any agent prompt.
+ *
+ * Returns an empty string if no snapshots are available (tolerate gracefully).
+ */
+export async function buildTelemetryPromptSection(snapshotCount: number = 20): Promise<string> {
+  const snapshots = await fetchRecentSnapshots(snapshotCount);
+  if (snapshots.length === 0) {
+    return '## Current simulation state\n_No telemetry data available yet._\n';
+  }
+  const summary = buildSummary(snapshots);
+  return formatForPrompt(summary);
+}
+```

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
-import { World, DEFAULT_CONFIG } from './world/World';
+```typescript
+import { World, DEFAULT_CONFIG, TelemetrySnapshot } from './world/World';
 import { Renderer } from './render/Renderer';
 
 // ── Container ──────────────────────────────────────────────────────────────────
@@ -99,6 +100,62 @@ function updateHUD(): void {
   }
 }
 
+// ── Telemetry ──────────────────────────────────────────────────────────────────
+
+const TELEMETRY_INTERVAL_MS = 60_000;
+const TELEMETRY_ENDPOINT = '/api/telemetry';
+
+/**
+ * Post a snapshot to the telemetry endpoint.
+ * Fire-and-forget — we log failures but never throw.
+ */
+function postSnapshot(snapshot: TelemetrySnapshot): void {
+  fetch(TELEMETRY_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(snapshot),
+  }).catch(err => {
+    console.warn('[telemetry] Failed to post snapshot:', err);
+  });
+}
+
+/**
+ * Capture a snapshot and optionally attach a canvas JPEG.
+ * Canvas capture is only performed when anomalies are present, keeping
+ * toDataURL() off the render hot-path.
+ */
+function captureAndPost(forceCanvasCapture: boolean = false): void {
+  // First pass: compute snapshot without canvas to check for anomalies
+  const preliminary = world.captureSnapshot();
+  const hasAnomaly = preliminary.anomalies.length > 0;
+
+  if (hasAnomaly || forceCanvasCapture) {
+    // Only do the synchronous GPU readback when we actually need an image
+    let dataUrl: string | undefined;
+    try {
+      dataUrl = renderer.renderer.domElement.toDataURL('image/jpeg', 0.4);
+    } catch {
+      // toDataURL can fail if canvas is tainted or context is lost
+      dataUrl = undefined;
+    }
+    // Re-capture with canvas attached (snapshot is cheap — no O(n²) ops)
+    const fullSnapshot = world.captureSnapshot(dataUrl);
+    postSnapshot(fullSnapshot);
+
+    if (hasAnomaly) {
+      console.info(
+        '[telemetry] Anomaly snapshot posted:',
+        fullSnapshot.anomalies.map(a => a.description).join('; '),
+      );
+    }
+  } else {
+    postSnapshot(preliminary);
+  }
+}
+
+// Periodic snapshot — every 60 seconds regardless of anomalies
+setInterval(() => captureAndPost(), TELEMETRY_INTERVAL_MS);
+
 // ── Main loop ──────────────────────────────────────────────────────────────────
 
 const FIXED_DT = 1 / 60;
@@ -125,3 +182,4 @@ function loop(): void {
 }
 
 requestAnimationFrame(loop);
+```

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -1,3 +1,4 @@
+```typescript
 import { Agent } from '../agent/Agent';
 import { Genome } from '../agent/Genome';
 import { Environment } from './Environment';
@@ -18,6 +19,152 @@ export const DEFAULT_CONFIG: WorldConfig = {
   zoneCount: 12,   // 2-D food landscape on XZ plane
 };
 
+// ── Telemetry types ────────────────────────────────────────────────────────────
+
+export interface TelemetrySnapshot {
+  timestamp: number;        // wall-clock ms
+  simTime: number;          // simulation seconds
+  stepCount: number;
+
+  // Metric 1: genome diversity — mean L2 distance from rolling centroid (O(nk))
+  genomeDiversity: number;
+
+  // Metric 2: birth/death ratio trend over last 500 frames
+  birthRate: number;        // births per 100 frames in window
+  deathRate: number;        // deaths per 100 frames in window
+  birthDeathRatio: number;
+
+  // Metric 3: diversity rate of change (first derivative vs. last snapshot)
+  diversityDelta: number;
+
+  // Metric 4: spatial entropy of agent positions in a 16×16 grid
+  spatialEntropy: number;
+
+  // Population basics
+  agentCount: number;
+  meanEnergy: number;
+  stddevEnergy: number;
+
+  // Anomaly flags — fires when a metric deviates beyond threshold from baseline
+  anomalies: AnomalyFlag[];
+
+  // Optional low-res canvas snapshot — only populated when anomaly fires
+  canvasSnapshot?: string;
+}
+
+export interface AnomalyFlag {
+  metric: string;
+  description: string;
+  value: number;
+  baseline: number;
+  sigmas: number;
+}
+
+// Rolling window size for birth/death tracking
+const BIRTH_DEATH_WINDOW = 500;
+// Number of past diversity values to keep for baseline / rate-of-change
+const DIVERSITY_HISTORY_LEN = 20;
+// Anomaly threshold in standard deviations
+const ANOMALY_SIGMA = 2.0;
+// Spatial grid resolution
+const GRID_SIZE = 16;
+
+// ── Telemetry tracker (lives inside World, updated each step) ─────────────────
+
+class TelemetryTracker {
+  // Birth/death ring buffers (1 = event in that frame, 0 = none)
+  private _birthCounts: number[] = new Array(BIRTH_DEATH_WINDOW).fill(0);
+  private _deathCounts: number[] = new Array(BIRTH_DEATH_WINDOW).fill(0);
+  private _windowIdx = 0;
+
+  private _birthTotal = 0;
+  private _deathTotal = 0;
+
+  // Rolling diversity history
+  private _diversityHistory: number[] = [];
+
+  // Rolling baseline for anomaly detection per metric
+  private _baseline: Map<string, { values: number[]; mean: number; stddev: number }> = new Map();
+
+  // Last snapshot's diversity value for rate-of-change
+  private _lastSnapshotDiversity: number | null = null;
+
+  recordBirth(): void {
+    this._birthTotal -= this._birthCounts[this._windowIdx];
+    this._birthCounts[this._windowIdx] = (this._birthCounts[this._windowIdx] ?? 0) + 1;
+    this._birthTotal += 1;
+  }
+
+  recordDeath(): void {
+    this._deathTotal -= this._deathCounts[this._windowIdx];
+    this._deathCounts[this._windowIdx] = (this._deathCounts[this._windowIdx] ?? 0) + 1;
+    this._deathTotal += 1;
+  }
+
+  advanceFrame(): void {
+    this._windowIdx = (this._windowIdx + 1) % BIRTH_DEATH_WINDOW;
+    // Clear the slot we're about to overwrite
+    this._birthTotal -= this._birthCounts[this._windowIdx];
+    this._birthCounts[this._windowIdx] = 0;
+    this._deathTotal -= this._deathCounts[this._windowIdx];
+    this._deathCounts[this._windowIdx] = 0;
+  }
+
+  get birthRate(): number {
+    return (this._birthTotal / BIRTH_DEATH_WINDOW) * 100;
+  }
+
+  get deathRate(): number {
+    return (this._deathTotal / BIRTH_DEATH_WINDOW) * 100;
+  }
+
+  recordDiversity(value: number): void {
+    this._diversityHistory.push(value);
+    if (this._diversityHistory.length > DIVERSITY_HISTORY_LEN) {
+      this._diversityHistory.shift();
+    }
+  }
+
+  get diversityDeltaSinceLastSnapshot(): number {
+    const current = this._diversityHistory[this._diversityHistory.length - 1] ?? 0;
+    if (this._lastSnapshotDiversity === null) return 0;
+    const delta = current - this._lastSnapshotDiversity;
+    this._lastSnapshotDiversity = current;
+    return delta;
+  }
+
+  markSnapshotDiversity(value: number): void {
+    this._lastSnapshotDiversity = value;
+  }
+
+  checkAnomaly(metric: string, value: number): AnomalyFlag | null {
+    if (!this._baseline.has(metric)) {
+      this._baseline.set(metric, { values: [], mean: value, stddev: 0 });
+    }
+    const b = this._baseline.get(metric)!;
+    b.values.push(value);
+    if (b.values.length > 50) b.values.shift(); // rolling 50-sample baseline
+
+    const n = b.values.length;
+    if (n < 5) return null; // not enough data yet
+
+    const mean = b.values.reduce((s, v) => s + v, 0) / n;
+    const variance = b.values.reduce((s, v) => s + (v - mean) ** 2, 0) / n;
+    const stddev = Math.sqrt(variance);
+    b.mean = mean;
+    b.stddev = stddev;
+
+    if (stddev < 1e-9) return null;
+    const sigmas = Math.abs(value - mean) / stddev;
+    if (sigmas >= ANOMALY_SIGMA) {
+      return { metric, description: `${metric} deviated ${sigmas.toFixed(1)}σ from baseline`, value, baseline: mean, sigmas };
+    }
+    return null;
+  }
+}
+
+// ── World ─────────────────────────────────────────────────────────────────────
+
 export class World {
   agents: Agent[] = [];
   env: Environment;
@@ -30,6 +177,8 @@ export class World {
 
   // Phylogeny log: [childId, parentId, generation, birthTime]
   lineageLog: Array<[number, number | null, number, number]> = [];
+
+  readonly telemetry: TelemetryTracker = new TelemetryTracker();
 
   constructor(cfg: WorldConfig) {
     this.worldWidth = cfg.worldWidth;
@@ -62,6 +211,7 @@ export class World {
   update(dt: number): void {
     this.time += dt;
     this.stepCount++;
+    this.telemetry.advanceFrame();
     this.env.update(dt);
 
     const offspring: Agent[] = [];
@@ -72,10 +222,19 @@ export class World {
       if (agent.dead) continue;
 
       // Max lifespan: forces generational turnover
-      if (agent.age > 180) { agent.dead = true; liveCount--; continue; }
+      if (agent.age > 180) {
+        agent.dead = true;
+        liveCount--;
+        this.telemetry.recordDeath();
+        continue;
+      }
 
       agent.update(dt, this.env.zones, this.worldWidth, this.worldDepth);
-      if (agent.dead) { liveCount--; continue; }
+      if (agent.dead) {
+        liveCount--;
+        this.telemetry.recordDeath();
+        continue;
+      }
 
       // Energy harvesting: each node that overlaps a zone absorbs energy
       for (const node of agent.nodes) {
@@ -88,6 +247,7 @@ export class World {
         const child = agent.reproduce();
         offspring.push(child);
         this.lineageLog.push([child.id, child.parentId, child.generation, child.birthTime]);
+        this.telemetry.recordBirth();
       }
     }
 
@@ -101,6 +261,152 @@ export class World {
         this._spawn(Genome.random());
       }
     }
+
+    // Update rolling diversity history every frame (cheap: O(nk))
+    const diversity = this._computeGenomeDiversity();
+    this.telemetry.recordDiversity(diversity);
+  }
+
+  // ── Telemetry snapshot ────────────────────────────────────────────────────────
+
+  /**
+   * Capture a telemetry snapshot using only O(n) and O(nk) metrics.
+   * Safe to call off the render hot-path (e.g. from a setInterval).
+   * Pass a canvasDataUrl only when an anomaly has already been detected.
+   */
+  captureSnapshot(canvasDataUrl?: string): TelemetrySnapshot {
+    const n = this.agents.length;
+
+    // ── Metric 1: genome diversity (rolling centroid distance, O(nk)) ──────────
+    const genomeDiversity = this._computeGenomeDiversity();
+
+    // ── Metric 2: birth/death ratio trend ─────────────────────────────────────
+    const birthRate = this.telemetry.birthRate;
+    const deathRate = this.telemetry.deathRate;
+    const birthDeathRatio = deathRate < 1e-6 ? birthRate : birthRate / deathRate;
+
+    // ── Metric 3: diversity rate of change ────────────────────────────────────
+    const diversityDelta = this.telemetry.diversityDeltaSinceLastSnapshot;
+    this.telemetry.markSnapshotDiversity(genomeDiversity);
+
+    // ── Metric 4: spatial entropy (16×16 grid, O(n)) ──────────────────────────
+    const spatialEntropy = this._computeSpatialEntropy();
+
+    // ── Population basics (O(n)) ──────────────────────────────────────────────
+    let meanEnergy = 0;
+    for (const a of this.agents) meanEnergy += a.energy;
+    if (n > 0) meanEnergy /= n;
+
+    let variance = 0;
+    for (const a of this.agents) variance += (a.energy - meanEnergy) ** 2;
+    const stddevEnergy = n > 1 ? Math.sqrt(variance / n) : 0;
+
+    // ── Anomaly detection ─────────────────────────────────────────────────────
+    const anomalies: AnomalyFlag[] = [];
+    const checks: Array<[string, number]> = [
+      ['genomeDiversity', genomeDiversity],
+      ['birthDeathRatio', birthDeathRatio],
+      ['spatialEntropy', spatialEntropy],
+      ['meanEnergy', meanEnergy],
+      ['diversityDelta', Math.abs(diversityDelta)],
+    ];
+    for (const [metric, value] of checks) {
+      const flag = this.telemetry.checkAnomaly(metric, value);
+      if (flag) anomalies.push(flag);
+    }
+
+    return {
+      timestamp: Date.now(),
+      simTime: this.time,
+      stepCount: this.stepCount,
+      genomeDiversity,
+      birthRate,
+      deathRate,
+      birthDeathRatio,
+      diversityDelta,
+      spatialEntropy,
+      agentCount: n,
+      meanEnergy,
+      stddevEnergy,
+      anomalies,
+      canvasSnapshot: canvasDataUrl,
+    };
+  }
+
+  /**
+   * Compute mean L2 distance of each agent's genome feature vector from the
+   * population centroid. O(nk) where k = node count × features per node.
+   * Uses a fixed feature set: node dx, dy, dz, mass, radius per node (capped at
+   * 7 nodes = 35 features) for a bounded, comparable representation.
+   */
+  private _computeGenomeDiversity(): number {
+    const n = this.agents.length;
+    if (n < 2) return 0;
+
+    const FEATURES_PER_NODE = 5; // dx, dy, dz, mass, radius
+    const MAX_NODES = 7;
+    const K = MAX_NODES * FEATURES_PER_NODE;
+
+    // Build centroid
+    const centroid = new Float64Array(K);
+    for (const agent of this.agents) {
+      const nodes = agent.genome.nodes.slice(0, MAX_NODES);
+      for (let i = 0; i < nodes.length; i++) {
+        const base = i * FEATURES_PER_NODE;
+        centroid[base + 0] += nodes[i].dx;
+        centroid[base + 1] += nodes[i].dy;
+        centroid[base + 2] += nodes[i].dz;
+        centroid[base + 3] += nodes[i].mass;
+        centroid[base + 4] += nodes[i].radius;
+      }
+    }
+    for (let j = 0; j < K; j++) centroid[j] /= n;
+
+    // Mean L2 distance from centroid
+    let totalDist = 0;
+    for (const agent of this.agents) {
+      const nodes = agent.genome.nodes.slice(0, MAX_NODES);
+      let distSq = 0;
+      for (let i = 0; i < nodes.length; i++) {
+        const base = i * FEATURES_PER_NODE;
+        distSq += (nodes[i].dx    - centroid[base + 0]) ** 2;
+        distSq += (nodes[i].dy    - centroid[base + 1]) ** 2;
+        distSq += (nodes[i].dz    - centroid[base + 2]) ** 2;
+        distSq += (nodes[i].mass  - centroid[base + 3]) ** 2;
+        distSq += (nodes[i].radius - centroid[base + 4]) ** 2;
+      }
+      totalDist += Math.sqrt(distSq);
+    }
+    return totalDist / n;
+  }
+
+  /**
+   * Shannon entropy of agent positions in a GRID_SIZE×GRID_SIZE spatial grid.
+   * O(n) — bins each agent then computes entropy over cell occupancy counts.
+   */
+  private _computeSpatialEntropy(): number {
+    const n = this.agents.length;
+    if (n === 0) return 0;
+
+    const cells = new Float64Array(GRID_SIZE * GRID_SIZE);
+    const scaleX = GRID_SIZE / this.worldWidth;
+    const scaleZ = GRID_SIZE / this.worldDepth;
+
+    for (const agent of this.agents) {
+      const c = agent.centerPos;
+      const gx = Math.min(GRID_SIZE - 1, Math.floor(c.x * scaleX));
+      const gz = Math.min(GRID_SIZE - 1, Math.floor(c.z * scaleZ));
+      cells[gz * GRID_SIZE + gx]++;
+    }
+
+    let entropy = 0;
+    for (let i = 0; i < cells.length; i++) {
+      if (cells[i] > 0) {
+        const p = cells[i] / n;
+        entropy -= p * Math.log2(p);
+      }
+    }
+    return entropy;
   }
 
   get stats() {
@@ -115,3 +421,4 @@ export class World {
     };
   }
 }
+```


### PR DESCRIPTION
## Summary

- Adds a lightweight telemetry pipeline that captures evolutionary trajectory metrics every 60 seconds and routes them back to the governance system so agents can observe simulation outcomes when evaluating proposals.
- Implements exactly the four O(n)/O(nk) metrics agreed in consensus: rolling genome centroid distance (diversity), birth/death ratio trend over 500 frames, diversity rate of change, and spatial grid entropy — no O(n²) pairwise diff, no continuous `toDataURL`.
- Canvas snapshots are only taken when an anomaly fires (>2σ deviation from rolling baseline), keeping the GPU readback off the render hot-path.
- Agent prompts receive delta-formatted summaries (`current`, `Δ last 5`, `Δ last 20`, `trend`) rather than raw snapshots, so agents reason about trajectory not instantaneous state. Storage uses Vercel KV (not Gist) to avoid race conditions with concurrent tabs.

## Changes

**`src/world/World.ts`**
Adds `TelemetryTracker` (ring-buffer birth/death counts, rolling diversity history, per-metric anomaly baseline) and `World.captureSnapshot()` — the four consensus metrics plus population basics and anomaly flags. Also records births and deaths inline in `update()` via `telemetry.recordBirth()` / `recordDeath()`, and updates the rolling diversity history each frame using `_computeGenomeDiversity()` (O(nk), fixed feature vector capped at 7 nodes).

**`src/main.ts`**
Adds a 60-second `setInterval` that calls `captureAndPost()`. Anomaly detection is done by inspecting the preliminary snapshot; `toDataURL` is only called if anomalies are present or a force-capture is requested. Posts JSON to `/api/telemetry` as fire-and-forget.

**`api/telemetry.ts`** *(new)*
Vercel serverless endpoint. Receives snapshot JSON, validates required fields, prepends to a capped Redis LIST in Vercel KV (`crucible:telemetry:snapshots`, max 100 entries), and writes a quick-read `crucible:telemetry:latest` key. Returns `200 { ok: true }`.

**`orchestrator/src/telemetry.ts`** *(new)*
Client-side helper for the orchestrator. `fetchRecentSnapshots(n)` reads from Vercel KV. `buildSummary()` computes per-metric `{current, delta5, delta20, trend}` structs and de-duplicates recent anomaly flags. `formatForPrompt()` renders a Markdown table with delta-first formatting. `buildTelemetryPromptSection()` is the single export for dispatch.ts to call — it fetches, summarises, and formats in one step, returning an empty stub if no data is available yet.

## Test plan
- [ ] Run `npm run dev` and verify the simulation starts without errors
- [ ] Open the browser console and confirm no errors appear at startup
- [ ] Wait 60 seconds and verify `[telemetry]` log entries appear (or a `Failed to post` warning if KV is unconfigured — both are acceptable)
- [ ] Trigger a fast population crash (open console, `sim.world.agents.forEach(a => a.dead = true)`) and confirm an anomaly snapshot is logged within the next telemetry cycle
- [ ] Verify the canvas JPEG is only attached when anomalies are present (check the JSON body in the network tab)
- [ ] With `KV_REST_API_URL` and `KV_REST_API_TOKEN` set, hit `POST /api/telemetry` with a valid snapshot body and confirm `200 { ok: true }`
- [ ] Call `buildTelemetryPromptSection()` from the orchestrator context and confirm it returns a Markdown table with delta columns

Closes #10