### PR TITLE
feat: implement #12 — [PROPOSAL] Crowding & scale: right-size the world before complexity grows

### DIFF
--- a/orchestrator/implement-pr-body.md
+++ b/orchestrator/implement-pr-body.md
@@ -1,31 +1,25 @@
 ## Summary
-
-- Adds a lightweight telemetry pipeline that captures evolutionary trajectory metrics every 60 seconds and routes them back to the governance system so agents can observe simulation outcomes when evaluating proposals.
-- Implements exactly the four O(n)/O(nk) metrics agreed in consensus: rolling genome centroid distance (diversity), birth/death ratio trend over 500 frames, diversity rate of change, and spatial grid entropy — no O(n²) pairwise diff, no continuous `toDataURL`.
-- Canvas snapshots are only taken when an anomaly fires (>2σ deviation from rolling baseline), keeping the GPU readback off the render hot-path.
-- Agent prompts receive delta-formatted summaries (`current`, `Δ last 5`, `Δ last 20`, `trend`) rather than raw snapshots, so agents reason about trajectory not instantaneous state. Storage uses Vercel KV (not Gist) to avoid race conditions with concurrent tabs.
+- Increased `zoneCount` from 12 → 24 in `DEFAULT_CONFIG` — the primary Sprint 1 config change agreed by consensus, redistributing food across more zones to reduce bottleneck clustering around 12 fixed attractors
+- Added `energyAcquisitionVariance` metric to telemetry: tracks per-agent energy gained each frame; low variance signals undifferentiated scramble competition, rising variance signals niche formation — the key crowding diagnostic the panel requested
+- Added `morphologicalVarianceByGeneration` metric: computes mean morphological distance from the bucket centroid for four generation cohorts (0–9, 10–19, 20–49, 50+); collapsing variance across generations is the measurable signal that crowding is homogenising rather than differentiating
+- No world size, agent count, or agent radius changes — held per consensus; depletable zones explicitly deferred to Sprint 2
 
 ## Changes
-
 **`src/world/World.ts`**
-Adds `TelemetryTracker` (ring-buffer birth/death counts, rolling diversity history, per-metric anomaly baseline) and `World.captureSnapshot()` — the four consensus metrics plus population basics and anomaly flags. Also records births and deaths inline in `update()` via `telemetry.recordBirth()` / `recordDeath()`, and updates the rolling diversity history each frame using `_computeGenomeDiversity()` (O(nk), fixed feature vector capped at 7 nodes).
-
-**`src/main.ts`**
-Adds a 60-second `setInterval` that calls `captureAndPost()`. Anomaly detection is done by inspecting the preliminary snapshot; `toDataURL` is only called if anomalies are present or a force-capture is requested. Posts JSON to `/api/telemetry` as fire-and-forget.
-
-**`api/telemetry.ts`** *(new)*
-Vercel serverless endpoint. Receives snapshot JSON, validates required fields, prepends to a capped Redis LIST in Vercel KV (`crucible:telemetry:snapshots`, max 100 entries), and writes a quick-read `crucible:telemetry:latest` key. Returns `200 { ok: true }`.
-
-**`orchestrator/src/telemetry.ts`** *(new)*
-Client-side helper for the orchestrator. `fetchRecentSnapshots(n)` reads from Vercel KV. `buildSummary()` computes per-metric `{current, delta5, delta20, trend}` structs and de-duplicates recent anomaly flags. `formatForPrompt()` renders a Markdown table with delta-first formatting. `buildTelemetryPromptSection()` is the single export for dispatch.ts to call — it fetches, summarises, and formats in one step, returning an empty stub if no data is available yet.
+- `DEFAULT_CONFIG.zoneCount`: `12` → `24`
+- Added `GenerationVarianceBucket` interface to exports
+- Extended `TelemetrySnapshot` with `energyAcquisitionVariance: number` and `morphologicalVarianceByGeneration: GenerationVarianceBucket[]`
+- Added `_frameEnergyGained: Map<number, number>` field on `World`; populated in `update()` during the harvest loop
+- Added `_computeEnergyAcquisitionVariance()` — O(n), uses the frame map
+- Added `_computeMorphologicalVarianceByGeneration()` — O(nk) over four generation buckets, same feature encoding as existing `_computeGenomeDiversity`
+- Both new metrics wired into `captureSnapshot()`; `energyAcquisitionVariance` also added to the anomaly-detection checks
 
 ## Test plan
 - [ ] Run `npm run dev` and verify the simulation starts without errors
-- [ ] Open the browser console and confirm no errors appear at startup
-- [ ] Wait 60 seconds and verify `[telemetry]` log entries appear (or a `Failed to post` warning if KV is unconfigured — both are acceptable)
-- [ ] Trigger a fast population crash (open console, `sim.world.agents.forEach(a => a.dead = true)`) and confirm an anomaly snapshot is logged within the next telemetry cycle
-- [ ] Verify the canvas JPEG is only attached when anomalies are present (check the JSON body in the network tab)
-- [ ] With `KV_REST_API_URL` and `KV_REST_API_TOKEN` set, hit `POST /api/telemetry` with a valid snapshot body and confirm `200 { ok: true }`
-- [ ] Call `buildTelemetryPromptSection()` from the orchestrator context and confirm it returns a Markdown table with delta columns
+- [ ] Confirm 24 zone discs render across the world (more evenly spread than before)
+- [ ] Let the simulation run for ~200 generations; open devtools and call `sim.world.captureSnapshot()` — verify `energyAcquisitionVariance` and `morphologicalVarianceByGeneration` are present and non-zero
+- [ ] Verify `morphologicalVarianceByGeneration` buckets populate correctly as generation count grows (early runs will only have the `0–9` bucket populated)
+- [ ] Check browser console for runtime errors
+- [ ] Visually confirm agents are less clumped than with 12 zones
 
-Closes #10
+Closes #12

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -16,7 +16,7 @@ export const DEFAULT_CONFIG: WorldConfig = {
   worldDepth: 1200,
   initialAgents: 16,
   maxAgents: 60,
-  zoneCount: 12,   // 2-D food landscape on XZ plane
+  zoneCount: 24,   // increased from 12 → 24 to distribute agents and reduce bottlenecking
 };
 
 // ── Telemetry types ────────────────────────────────────────────────────────────
@@ -40,6 +40,14 @@ export interface TelemetrySnapshot {
   // Metric 4: spatial entropy of agent positions in a 16×16 grid
   spatialEntropy: number;
 
+  // Metric 5: variance in per-agent energy-acquisition rate (crowding diagnostic)
+  // High variance = niche differentiation forming; low variance = scramble competition
+  energyAcquisitionVariance: number;
+
+  // Metric 6: morphological variance broken down by generation bucket
+  // Tracks whether crowding causes convergence (collapse) or divergence (niche carving)
+  morphologicalVarianceByGeneration: GenerationVarianceBucket[];
+
   // Population basics
   agentCount: number;
   meanEnergy: number;
@@ -50,6 +58,14 @@ export interface TelemetrySnapshot {
 
   // Optional low-res canvas snapshot — only populated when anomaly fires
   canvasSnapshot?: string;
+}
+
+export interface GenerationVarianceBucket {
+  /** Generation range label, e.g. "0–9", "10–19", "20+" */
+  label: string;
+  agentCount: number;
+  /** Mean L2 morphological distance from the bucket's own centroid */
+  morphVariance: number;
 }
 
 export interface AnomalyFlag {
@@ -180,6 +196,10 @@ export class World {
 
   readonly telemetry: TelemetryTracker = new TelemetryTracker();
 
+  // Per-agent energy gained in the current frame (keyed by agent id)
+  // Used to compute energy-acquisition variance for the crowding diagnostic
+  private _frameEnergyGained: Map<number, number> = new Map();
+
   constructor(cfg: WorldConfig) {
     this.worldWidth = cfg.worldWidth;
     this.worldDepth = cfg.worldDepth;
@@ -214,6 +234,9 @@ export class World {
     this.telemetry.advanceFrame();
     this.env.update(dt);
 
+    // Reset per-frame energy tracking
+    this._frameEnergyGained.clear();
+
     const offspring: Agent[] = [];
 
     let liveCount = this.agents.reduce((n, a) => n + (a.dead ? 0 : 1), 0);
@@ -237,10 +260,16 @@ export class World {
       }
 
       // Energy harvesting: each node that overlaps a zone absorbs energy
+      let frameGained = 0;
       for (const node of agent.nodes) {
         const gained = this.env.harvest(node.pos.x, node.pos.y, node.pos.z, node.radius);
-        if (gained > 0) agent.absorbEnergy(gained * 18);
+        if (gained > 0) {
+          const absorbed = gained * 18;
+          agent.absorbEnergy(absorbed);
+          frameGained += absorbed;
+        }
       }
+      this._frameEnergyGained.set(agent.id, frameGained);
 
       // Reproduction
       if (agent.canReproduce() && liveCount + offspring.length < this.maxAgents) {
@@ -292,6 +321,18 @@ export class World {
     // ── Metric 4: spatial entropy (16×16 grid, O(n)) ──────────────────────────
     const spatialEntropy = this._computeSpatialEntropy();
 
+    // ── Metric 5: energy-acquisition variance ─────────────────────────────────
+    // A crowding/niche-differentiation diagnostic.
+    // If crowding is producing scramble competition, all agents get roughly the
+    // same (low) energy per frame → low variance.
+    // If niches are forming, some agents reliably out-acquire others → high variance.
+    const energyAcquisitionVariance = this._computeEnergyAcquisitionVariance();
+
+    // ── Metric 6: morphological variance by generation bucket ─────────────────
+    // Tells us whether selection is differentiating body plans across generations
+    // or driving convergence. Collapsing variance per bucket = scramble selection.
+    const morphologicalVarianceByGeneration = this._computeMorphologicalVarianceByGeneration();
+
     // ── Population basics (O(n)) ──────────────────────────────────────────────
     let meanEnergy = 0;
     for (const a of this.agents) meanEnergy += a.energy;
@@ -309,6 +350,7 @@ export class World {
       ['spatialEntropy', spatialEntropy],
       ['meanEnergy', meanEnergy],
       ['diversityDelta', Math.abs(diversityDelta)],
+      ['energyAcquisitionVariance', energyAcquisitionVariance],
     ];
     for (const [metric, value] of checks) {
       const flag = this.telemetry.checkAnomaly(metric, value);
@@ -325,6 +367,8 @@ export class World {
       birthDeathRatio,
       diversityDelta,
       spatialEntropy,
+      energyAcquisitionVariance,
+      morphologicalVarianceByGeneration,
       agentCount: n,
       meanEnergy,
       stddevEnergy,
@@ -407,6 +451,104 @@ export class World {
       }
     }
     return entropy;
+  }
+
+  /**
+   * Variance in per-agent energy-acquisition rate across the current frame.
+   * Uses the _frameEnergyGained map populated during update().
+   *
+   * Low variance → all agents acquiring similar energy → undifferentiated scramble.
+   * Rising variance → some agents reliably out-acquire others → niche formation.
+   */
+  private _computeEnergyAcquisitionVariance(): number {
+    const n = this.agents.length;
+    if (n < 2) return 0;
+
+    let sum = 0;
+    for (const agent of this.agents) {
+      sum += this._frameEnergyGained.get(agent.id) ?? 0;
+    }
+    const mean = sum / n;
+
+    let varSum = 0;
+    for (const agent of this.agents) {
+      const gained = this._frameEnergyGained.get(agent.id) ?? 0;
+      varSum += (gained - mean) ** 2;
+    }
+    return varSum / n;
+  }
+
+  /**
+   * For each generation bucket (0–9, 10–19, 20–49, 50+), compute the mean
+   * morphological L2 distance from that bucket's own centroid.
+   *
+   * If crowding drives convergence, variance should collapse toward zero for
+   * mature generation buckets. If niches are forming, variance should remain
+   * high or grow. This is the primary "is crowding doing useful work?" signal.
+   */
+  private _computeMorphologicalVarianceByGeneration(): GenerationVarianceBucket[] {
+    const FEATURES_PER_NODE = 5;
+    const MAX_NODES = 7;
+    const K = MAX_NODES * FEATURES_PER_NODE;
+
+    // Define buckets: [label, minGen, maxGen (exclusive)]
+    const bucketDefs: Array<[string, number, number]> = [
+      ['0–9',   0,  10],
+      ['10–19', 10, 20],
+      ['20–49', 20, 50],
+      ['50+',   50, Infinity],
+    ];
+
+    const results: GenerationVarianceBucket[] = [];
+
+    for (const [label, minGen, maxGen] of bucketDefs) {
+      const bucket = this.agents.filter(
+        a => a.generation >= minGen && a.generation < maxGen,
+      );
+      if (bucket.length < 2) {
+        results.push({ label, agentCount: bucket.length, morphVariance: 0 });
+        continue;
+      }
+
+      // Compute centroid for this bucket
+      const centroid = new Float64Array(K);
+      for (const agent of bucket) {
+        const nodes = agent.genome.nodes.slice(0, MAX_NODES);
+        for (let i = 0; i < nodes.length; i++) {
+          const base = i * FEATURES_PER_NODE;
+          centroid[base + 0] += nodes[i].dx;
+          centroid[base + 1] += nodes[i].dy;
+          centroid[base + 2] += nodes[i].dz;
+          centroid[base + 3] += nodes[i].mass;
+          centroid[base + 4] += nodes[i].radius;
+        }
+      }
+      for (let j = 0; j < K; j++) centroid[j] /= bucket.length;
+
+      // Mean L2 distance from bucket centroid
+      let totalDist = 0;
+      for (const agent of bucket) {
+        const nodes = agent.genome.nodes.slice(0, MAX_NODES);
+        let distSq = 0;
+        for (let i = 0; i < nodes.length; i++) {
+          const base = i * FEATURES_PER_NODE;
+          distSq += (nodes[i].dx    - centroid[base + 0]) ** 2;
+          distSq += (nodes[i].dy    - centroid[base + 1]) ** 2;
+          distSq += (nodes[i].dz    - centroid[base + 2]) ** 2;
+          distSq += (nodes[i].mass  - centroid[base + 3]) ** 2;
+          distSq += (nodes[i].radius - centroid[base + 4]) ** 2;
+        }
+        totalDist += Math.sqrt(distSq);
+      }
+
+      results.push({
+        label,
+        agentCount: bucket.length,
+        morphVariance: totalDist / bucket.length,
+      });
+    }
+
+    return results;
   }
 
   get stats() {


### PR DESCRIPTION
## Summary
- Increased `zoneCount` from 12 → 24 in `DEFAULT_CONFIG` — the primary Sprint 1 config change agreed by consensus, redistributing food across more zones to reduce bottleneck clustering around 12 fixed attractors
- Added `energyAcquisitionVariance` metric to telemetry: tracks per-agent energy gained each frame; low variance signals undifferentiated scramble competition, rising variance signals niche formation — the key crowding diagnostic the panel requested
- Added `morphologicalVarianceByGeneration` metric: computes mean morphological distance from the bucket centroid for four generation cohorts (0–9, 10–19, 20–49, 50+); collapsing variance across generations is the measurable signal that crowding is homogenising rather than differentiating
- No world size, agent count, or agent radius changes — held per consensus; depletable zones explicitly deferred to Sprint 2

## Changes
**`src/world/World.ts`**
- `DEFAULT_CONFIG.zoneCount`: `12` → `24`
- Added `GenerationVarianceBucket` interface to exports
- Extended `TelemetrySnapshot` with `energyAcquisitionVariance: number` and `morphologicalVarianceByGeneration: GenerationVarianceBucket[]`
- Added `_frameEnergyGained: Map<number, number>` field on `World`; populated in `update()` during the harvest loop
- Added `_computeEnergyAcquisitionVariance()` — O(n), uses the frame map
- Added `_computeMorphologicalVarianceByGeneration()` — O(nk) over four generation buckets, same feature encoding as existing `_computeGenomeDiversity`
- Both new metrics wired into `captureSnapshot()`; `energyAcquisitionVariance` also added to the anomaly-detection checks

## Test plan
- [ ] Run `npm run dev` and verify the simulation starts without errors
- [ ] Confirm 24 zone discs render across the world (more evenly spread than before)
- [ ] Let the simulation run for ~200 generations; open devtools and call `sim.world.captureSnapshot()` — verify `energyAcquisitionVariance` and `morphologicalVarianceByGeneration` are present and non-zero
- [ ] Verify `morphologicalVarianceByGeneration` buckets populate correctly as generation count grows (early runs will only have the `0–9` bucket populated)
- [ ] Check browser console for runtime errors
- [ ] Visually confirm agents are less clumped than with 12 zones

Closes #12