### PR TITLE
feat: implement #14 — [PROPOSAL] Sensing architecture: what can agents perceive, and how should it scale?

### DIFF
--- a/orchestrator/implement-pr-body.md
+++ b/orchestrator/implement-pr-body.md
@@ -1,21 +1,19 @@
 ## Summary
-- Adds a static procedural `Heightfield` baked once at world-gen using multi-octave sine waves (no external dependency, deterministic, O(1) per height query via bilinear interpolation)
-- Threads terrain height through `PhysicsNode.constrainToGround(groundY, ...)`, `Agent.update(…, heightfield)`, and `World.update()` so every node rests on the actual terrain surface rather than a flat Y=0 plane
-- Agents are spawned on top of the terrain surface at their (x, z) position, creating immediate selection pressure for bodies that can navigate hills vs. valleys
-- Renders the terrain as a vertex-coloured, shaded `PlaneGeometry` deformed from the heightfield grid; ground-tier food discs are raised to sit on top of the terrain
+- Expands the neural network sensor input vector from **7 to 12 inputs** (Phase 1 of the sensing architecture upgrade agreed in #14)
+- Adds four new senses: Z-velocity, distance to nearest food, nearest food zone energy level, and wall proximity (X and Z axes separately)
+- Defines the complete sensor slot layout as a documented table in `Genome.ts` — the single authoritative source of truth, designed to migrate cleanly to Option 3 evolvable allocation
+- All layout constants (`WALL_SENSE_RADIUS`, `FOOD_DISTANCE_SCALE`) are named exports, not magic numbers scattered across files
 
 ## Changes
-- **`src/world/Heightfield.ts`** *(new)* — `Heightfield` class: grid generation, bilinear `heightAt(x, z)` query
-- **`src/physics/PhysicsNode.ts`** — `constrainToGround` gains a `groundY: number = 0` first parameter; all existing call sites with no argument default to flat ground (backward-compatible)
-- **`src/agent/Agent.ts`** — `update()` accepts a `Heightfield` and passes per-node terrain height to `constrainToGround`; `_develop()` `shift` uses `spawnY` as the reference floor instead of hardcoded 0
-- **`src/world/World.ts`** — constructs and owns a `readonly heightfield`; `_spawn()` queries terrain height at spawn point; `update()` passes heightfield to each agent
-- **`src/render/Renderer.ts`** — replaces flat `PlaneGeometry` ground with a heightfield-deformed terrain mesh (vertex colours: dark-green valleys → brown hilltops); selection ring tracks terrain surface; no flat ground mesh left
+- **`src/agent/Genome.ts`**: `SENSOR_COUNT` bumped from 7 to 12. Added `WALL_SENSE_RADIUS` and `FOOD_DISTANCE_SCALE` named constants. Sensor layout table added as structured JSDoc comment — every slot is explicitly documented; no sense is silently hardcoded elsewhere.
+- **`src/agent/Agent.ts`**: `_sense()` signature extended to accept `worldWidth`/`worldDepth` (already available in `update()`). Implements slots 7–11: vel Z, food distance (tanh-normalised via `FOOD_DISTANCE_SCALE`), food zone fill ratio (0–1), and wall proximity for X and Z axes (0 = far, 1 = at wall, saturates within `WALL_SENSE_RADIUS`). `EnergyZone` interface extended to expose `maxEnergy` (already present on the actual zone objects from `Environment.ts`).
 
 ## Test plan
-- [ ] Run `npm run dev` and verify the simulation starts without errors
-- [ ] Observe undulating terrain rendered with green-to-brown height colouring
-- [ ] Confirm agents walk on top of the terrain surface (nodes don't clip through hills)
-- [ ] Confirm ground-tier food discs sit visually on the terrain rather than clipping into hills
-- [ ] Check browser console for runtime errors
+- [ ] Run `npm run dev` and verify the simulation starts without errors in the browser console
+- [ ] Confirm agents spawn and move — the neural net input size change should be transparent at runtime
+- [ ] Inspect `world.agents[0].genome.brain.inputSize` in the browser console — should be `12`
+- [ ] Observe that agents near world boundaries exhibit modified behaviour over generations (wall proximity signal active)
+- [ ] Verify depleted food zones are treated differently from full ones over time (food fill signal active)
+- [ ] Check browser console for runtime errors, especially NaN in neural forward pass
 
-Closes #15
+Closes #14

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -1,7 +1,7 @@
 import { PhysicsNode } from '../physics/PhysicsNode';
 import { Spring } from '../physics/Spring';
 import { Vec3 } from '../physics/Vec3';
-import { Genome, SENSOR_COUNT } from './Genome';
+import { Genome, SENSOR_COUNT, WALL_SENSE_RADIUS, FOOD_DISTANCE_SCALE } from './Genome';
 import { Heightfield } from '../world/Heightfield';
 
 let nextId = 0;
@@ -12,6 +12,7 @@ export interface EnergyZone {
   z: number;
   radius: number;
   energy: number;
+  maxEnergy: number;
 }
 
 function hueFromGeneration(baseHue: number): number {
@@ -128,11 +129,24 @@ export class Agent {
 
   // ── Sensing ──────────────────────────────────────────────────────────────────
 
-  private _sense(zones: EnergyZone[]): number[] {
+  /**
+   * Build the 12-element sensor input vector.
+   * Slot layout is defined in Genome.ts — this method is the single place where
+   * world-state queries are assembled into that layout.
+   */
+  private _sense(
+    zones: EnergyZone[],
+    worldWidth: number,
+    worldDepth: number,
+  ): number[] {
     const c = this.centerPos;
 
-    // Nearest energy zone direction (XZ plane distance matters most)
-    let nearestDx = 0, nearestDy = 0, nearestDz = 0, nearestDist = 3000;
+    // ── Food sensing ─────────────────────────────────────────────────────────
+    // Single pass: find nearest zone, record direction, distance, and fill level.
+    let nearestDx = 0, nearestDy = 0, nearestDz = 0;
+    let nearestDist = 3000;
+    let nearestFill = 0;   // zone.energy / zone.maxEnergy
+
     for (const z of zones) {
       const dx = z.x - c.x;
       const dy = (z.y ?? 0) - c.y;
@@ -143,23 +157,44 @@ export class Agent {
         nearestDx = dx;
         nearestDy = dy;
         nearestDz = dz;
+        nearestFill = z.maxEnergy > 0 ? z.energy / z.maxEnergy : 0;
       }
     }
     const dirScale = 1 / (nearestDist + 1);
 
-    // Own average X-velocity
-    let velX = 0;
-    for (const n of this.nodes) velX += n.vel.x;
-    velX /= this.nodes.length;
+    // ── Own velocity ─────────────────────────────────────────────────────────
+    let velX = 0, velZ = 0;
+    for (const n of this.nodes) {
+      velX += n.vel.x;
+      velZ += n.vel.z;
+    }
+    const invN = 1 / this.nodes.length;
+    velX *= invN;
+    velZ *= invN;
 
+    // ── Wall proximity ───────────────────────────────────────────────────────
+    // Approaches 1 when within WALL_SENSE_RADIUS of the nearest X (or Z) wall,
+    // 0 when at the world centre or beyond WALL_SENSE_RADIUS from any wall.
+    const distToNearestWallX = Math.min(c.x, worldWidth - c.x);
+    const distToNearestWallZ = Math.min(c.z, worldDepth - c.z);
+    const wallProxX = Math.max(0, 1 - distToNearestWallX / WALL_SENSE_RADIUS);
+    const wallProxZ = Math.max(0, 1 - distToNearestWallZ / WALL_SENSE_RADIUS);
+
+    // ── Assemble input vector (must match SENSOR_COUNT = 12) ─────────────────
+    // Slot indices are the authoritative layout — see Genome.ts for the table.
     return [
-      Math.min(1, this.energy / 250),               // 0: energy [0,1]
-      Math.tanh(nearestDx * dirScale * 5),           // 1: food X
-      Math.tanh(nearestDy * dirScale * 5),           // 2: food Y
-      Math.tanh(nearestDz * dirScale * 5),           // 3: food Z
-      Math.tanh(velX * 10),                          // 4: own vel X
-      Math.sin(this.phase),                          // 5: oscillator sin
-      Math.cos(this.phase),                          // 6: oscillator cos
+      /* 0 */ Math.min(1, this.energy / 250),               // own energy
+      /* 1 */ Math.tanh(nearestDx * dirScale * 5),           // food dir X
+      /* 2 */ Math.tanh(nearestDy * dirScale * 5),           // food dir Y
+      /* 3 */ Math.tanh(nearestDz * dirScale * 5),           // food dir Z
+      /* 4 */ Math.tanh(velX * 10),                          // own vel X
+      /* 5 */ Math.sin(this.phase),                          // oscillator sin
+      /* 6 */ Math.cos(this.phase),                          // oscillator cos
+      /* 7 */ Math.tanh(velZ * 10),                          // own vel Z
+      /* 8 */ Math.tanh(nearestDist / FOOD_DISTANCE_SCALE),  // food distance
+      /* 9 */ nearestFill,                                   // food zone energy
+      /* 10 */ wallProxX,                                    // wall proximity X
+      /* 11 */ wallProxZ,                                    // wall proximity Z
     ];
   }
 
@@ -176,7 +211,7 @@ export class Agent {
     this.phase += dt * (2.5 + Math.sin(this.phase * 0.3) * 0.5);
 
     // Brain → muscle activations
-    const inputs = this._sense(zones);
+    const inputs = this._sense(zones, worldWidth, worldDepth);
     const outputs = this.genome.brain.forward(inputs);
     for (let i = 0; i < this.muscles.length; i++) {
       this.muscles[i].activation = outputs[i % outputs.length];
@@ -254,6 +289,6 @@ export class Agent {
   }
 }
 
-// Sanity-check sensor count constant
+// Sanity-check: _sense() return length must equal SENSOR_COUNT
 const _check: number = SENSOR_COUNT;
 void _check;

--- a/src/agent/Genome.ts
+++ b/src/agent/Genome.ts
@@ -21,16 +21,36 @@ export interface SpringGene {
 }
 
 /**
- * Sensor layout (7 inputs):
- *   0: energy normalised [0,1]
- *   1: food direction dx (tanh-normalised)
- *   2: food direction dy
- *   3: food direction dz
- *   4: own velocity X (tanh-normalised)
- *   5: oscillator sin
- *   6: oscillator cos
+ * Sensor input layout — 12 inputs.
+ *
+ * This layout is the single source of truth for what agents can perceive.
+ * Every slot is listed here; no sense is silently "always on" or scattered
+ * across multiple files.  When Option 3 (evolvable sense allocation) is built,
+ * this table becomes the sense registry that genomes index into.
+ *
+ * Slot | Signal                        | Range   | Notes
+ * -----|-------------------------------|---------|------------------------------
+ *  0   | Own energy (normalised)       | [0, 1]  | energy / 250, clamped
+ *  1   | Food direction X (tanh)       | [-1, 1] | toward nearest zone
+ *  2   | Food direction Y (tanh)       | [-1, 1] | toward nearest zone
+ *  3   | Food direction Z (tanh)       | [-1, 1] | toward nearest zone
+ *  4   | Own velocity X (tanh)         | [-1, 1] | mean across nodes
+ *  5   | Oscillator sin(phase)         | [-1, 1] | internal rhythm
+ *  6   | Oscillator cos(phase)         | [-1, 1] | internal rhythm
+ *  7   | Own velocity Z (tanh)         | [-1, 1] | mean across nodes
+ *  8   | Distance to nearest food      | [0, 1]  | tanh-normalised (scale 300)
+ *  9   | Nearest food zone energy      | [0, 1]  | zone.energy / zone.maxEnergy
+ * 10   | Wall proximity X              | [0, 1]  | 1 = touching wall, 0 = centre
+ * 11   | Wall proximity Z              | [0, 1]  | 1 = touching wall, 0 = centre
  */
-export const SENSOR_COUNT = 7;
+export const SENSOR_COUNT = 12;
+
+/** Distance at which wall-proximity sensor saturates (world units). */
+export const WALL_SENSE_RADIUS = 200;
+
+/** Distance scale for food-distance tanh normalisation (world units). */
+export const FOOD_DISTANCE_SCALE = 300;
+
 export const HIDDEN_SIZE = 10;
 
 export class Genome {


### PR DESCRIPTION
## Summary
- Expands the neural network sensor input vector from **7 to 12 inputs** (Phase 1 of the sensing architecture upgrade agreed in #14)
- Adds four new senses: Z-velocity, distance to nearest food, nearest food zone energy level, and wall proximity (X and Z axes separately)
- Defines the complete sensor slot layout as a documented table in `Genome.ts` — the single authoritative source of truth, designed to migrate cleanly to Option 3 evolvable allocation
- All layout constants (`WALL_SENSE_RADIUS`, `FOOD_DISTANCE_SCALE`) are named exports, not magic numbers scattered across files

## Changes
- **`src/agent/Genome.ts`**: `SENSOR_COUNT` bumped from 7 to 12. Added `WALL_SENSE_RADIUS` and `FOOD_DISTANCE_SCALE` named constants. Sensor layout table added as structured JSDoc comment — every slot is explicitly documented; no sense is silently hardcoded elsewhere.
- **`src/agent/Agent.ts`**: `_sense()` signature extended to accept `worldWidth`/`worldDepth` (already available in `update()`). Implements slots 7–11: vel Z, food distance (tanh-normalised via `FOOD_DISTANCE_SCALE`), food zone fill ratio (0–1), and wall proximity for X and Z axes (0 = far, 1 = at wall, saturates within `WALL_SENSE_RADIUS`). `EnergyZone` interface extended to expose `maxEnergy` (already present on the actual zone objects from `Environment.ts`).

## Test plan
- [ ] Run `npm run dev` and verify the simulation starts without errors in the browser console
- [ ] Confirm agents spawn and move — the neural net input size change should be transparent at runtime
- [ ] Inspect `world.agents[0].genome.brain.inputSize` in the browser console — should be `12`
- [ ] Observe that agents near world boundaries exhibit modified behaviour over generations (wall proximity signal active)
- [ ] Verify depleted food zones are treated differently from full ones over time (food fill signal active)
- [ ] Check browser console for runtime errors, especially NaN in neural forward pass

Closes #14