### PR TITLE
feat: implement #21 — [PROPOSAL] Emergent trophic niches: predation, grazing, and growth from minimal physics

### DIFF
--- a/orchestrator/implement-pr-body.md
+++ b/orchestrator/implement-pr-body.md
@@ -1,19 +1,21 @@
 ## Summary
-- Expands the neural network sensor input vector from **7 to 12 inputs** (Phase 1 of the sensing architecture upgrade agreed in #14)
-- Adds four new senses: Z-velocity, distance to nearest food, nearest food zone energy level, and wall proximity (X and Z axes separately)
-- Defines the complete sensor slot layout as a documented table in `Genome.ts` — the single authoritative source of truth, designed to migrate cleanly to Option 3 evolvable allocation
-- All layout constants (`WALL_SENSE_RADIUS`, `FOOD_DISTANCE_SCALE`) are named exports, not magic numbers scattered across files
+
+- Adds **corpse energy depots** (Phase 1 of Proposal #21): when an agent dies of old age with meaningful energy, a temporary energy depot is left at its position on the terrain surface
+- Corpses decay to zero over ~20 seconds with no replenishment, making scavenging a real energy source without flooding the world
+- Agents can harvest from corpses via the existing `env.harvest()` path — no change to agent code needed
+- Corpses render as dark-red semi-transparent discs that fade as they decay, giving players a clear visual signal of where agents have died
 
 ## Changes
-- **`src/agent/Genome.ts`**: `SENSOR_COUNT` bumped from 7 to 12. Added `WALL_SENSE_RADIUS` and `FOOD_DISTANCE_SCALE` named constants. Sensor layout table added as structured JSDoc comment — every slot is explicitly documented; no sense is silently hardcoded elsewhere.
-- **`src/agent/Agent.ts`**: `_sense()` signature extended to accept `worldWidth`/`worldDepth` (already available in `update()`). Implements slots 7–11: vel Z, food distance (tanh-normalised via `FOOD_DISTANCE_SCALE`), food zone fill ratio (0–1), and wall proximity for X and Z axes (0 = far, 1 = at wall, saturates within `WALL_SENSE_RADIUS`). `EnergyZone` interface extended to expose `maxEnergy` (already present on the actual zone objects from `Environment.ts`).
+
+- **`src/world/Environment.ts`**: Added `CorpseDepot` interface; added `corpseDepots` array and `addCorpse()` method to `Environment`; extended `update()` to decay and cull spent corpses; extended `harvest()` to include corpse depots alongside food zones
+- **`src/world/World.ts`**: Added `_depositCorpse()` helper that places a corpse at terrain height below the dying agent; called on age-death path (where energy may be substantial); starvation deaths (energy ≤ 0) naturally produce no corpse
+- **`src/render/Renderer.ts`**: Added `_corpseVisuals` pool; added `_renderCorpses()` method rendering corpses as pooled dark-red `CircleGeometry` discs that scale with depot radius and fade with remaining energy; `_ensureCorpseVisuals()` grows the pool lazily to avoid allocation spikes
 
 ## Test plan
-- [ ] Run `npm run dev` and verify the simulation starts without errors in the browser console
-- [ ] Confirm agents spawn and move — the neural net input size change should be transparent at runtime
-- [ ] Inspect `world.agents[0].genome.brain.inputSize` in the browser console — should be `12`
-- [ ] Observe that agents near world boundaries exhibit modified behaviour over generations (wall proximity signal active)
-- [ ] Verify depleted food zones are treated differently from full ones over time (food fill signal active)
-- [ ] Check browser console for runtime errors, especially NaN in neural forward pass
+- [ ] Run `npm run dev` and verify the simulation starts without errors
+- [ ] Observe dark-red discs appearing on the ground after agents die of old age and fading over ~20 seconds
+- [ ] Verify agents visibly move toward and linger near corpse discs (scavenging pressure)
+- [ ] Confirm no corpse disc appears when an agent starves (energy ≤ 0 at death)
+- [ ] Check browser console for runtime errors during normal operation and after population reseeds
 
-Closes #14
+Closes #21

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { World } from '../world/World';
 import { Agent } from '../agent/Agent';
-import { EnergyZone } from '../world/Environment';
+import { EnergyZone, CorpseDepot } from '../world/Environment';
 import { Heightfield } from '../world/Heightfield';
 
 // Pre-allocate generous upper bounds — never reallocate during the sim
@@ -16,9 +16,16 @@ const TIER_COLORS = [
   new THREE.Color(0xff8c00),   // 2: high   — amber
 ];
 
+// Corpse visual colour — dark brownish-red
+const CORPSE_COLOR = new THREE.Color(0x8b2020);
+
 interface ZoneVisual {
   disc: THREE.Mesh;
   stem: THREE.Mesh | null; // null for ground-tier zones
+}
+
+interface CorpseVisual {
+  disc: THREE.Mesh;
 }
 
 export class Renderer {
@@ -42,6 +49,9 @@ export class Renderer {
 
   // ── energy zones ──
   private _zoneVisuals: ZoneVisual[] = [];
+
+  // ── corpse depot visuals ──
+  private _corpseVisuals: CorpseVisual[] = [];
 
   // ── selection indicator ──
   private _selectionRing: THREE.Mesh;
@@ -272,6 +282,30 @@ export class Renderer {
     }
   }
 
+  // ── Corpse visual pool ────────────────────────────────────────────────────────
+
+  /**
+   * Grow the corpse visual pool to match the current number of corpse depots.
+   * Corpses are rendered as small dark-red discs on the ground surface.
+   */
+  private _ensureCorpseVisuals(count: number): void {
+    while (this._corpseVisuals.length < count) {
+      const discGeo = new THREE.CircleGeometry(1, 16);
+      discGeo.rotateX(-Math.PI / 2);
+      const discMat = new THREE.MeshBasicMaterial({
+        color: CORPSE_COLOR.clone(),
+        transparent: true,
+        opacity: 0.6,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+      });
+      const disc = new THREE.Mesh(discGeo, discMat);
+      disc.visible = false;
+      this.scene.add(disc);
+      this._corpseVisuals.push({ disc });
+    }
+  }
+
   // ── Main render loop ──────────────────────────────────────────────────────────
 
   render(world: World): void {
@@ -283,6 +317,7 @@ export class Renderer {
     }
 
     this._renderZones(world);
+    this._renderCorpses(world);
     this._renderAgents(world);
     this._renderSelection(world.heightfield);
 
@@ -325,6 +360,34 @@ export class Renderer {
     for (let i = zones.length; i < this._zoneVisuals.length; i++) {
       this._zoneVisuals[i].disc.visible = false;
       if (this._zoneVisuals[i].stem) this._zoneVisuals[i].stem!.visible = false;
+    }
+  }
+
+  // ── Corpse rendering ──────────────────────────────────────────────────────────
+
+  private _renderCorpses(world: World): void {
+    const corpses = world.env.corpseDepots;
+    this._ensureCorpseVisuals(corpses.length);
+
+    for (let i = 0; i < corpses.length; i++) {
+      const corpse = corpses[i];
+      const vis = this._corpseVisuals[i];
+      const fillRatio = corpse.maxEnergy > 0 ? corpse.energy / corpse.maxEnergy : 0;
+
+      vis.disc.visible = fillRatio > 0.02;
+      if (!vis.disc.visible) continue;
+
+      // Sit just above the terrain surface
+      const discY = world.heightfield.heightAt(corpse.x, corpse.z) + 0.6;
+      vis.disc.scale.set(corpse.radius, 1, corpse.radius);
+      vis.disc.position.set(corpse.x, discY, corpse.z);
+      // Fade as the corpse decays
+      (vis.disc.material as THREE.MeshBasicMaterial).opacity = 0.15 + fillRatio * 0.55;
+    }
+
+    // Hide unused corpse visuals
+    for (let i = corpses.length; i < this._corpseVisuals.length; i++) {
+      this._corpseVisuals[i].disc.visible = false;
     }
   }
 

--- a/src/world/Environment.ts
+++ b/src/world/Environment.ts
@@ -10,6 +10,37 @@ export interface EnergyZone {
 }
 
 /**
+ * A temporary energy depot left when an agent dies.
+ * Decays to zero with no replenishment — corpses rot.
+ */
+export interface CorpseDepot {
+  x: number;
+  y: number;
+  z: number;
+  radius: number;
+  energy: number;
+  /** Initial energy, used for rendering fill level. */
+  maxEnergy: number;
+  /** Energy lost per second. Corpse lasts ~CORPSE_LIFETIME_S seconds. */
+  decayRate: number;
+}
+
+/** How many seconds a corpse at full energy takes to fully decay. */
+const CORPSE_LIFETIME_S = 20;
+
+/** Radius of a corpse depot in world units. */
+const CORPSE_RADIUS = 18;
+
+/** Fraction of the dying agent's energy deposited into the corpse. */
+const CORPSE_ENERGY_FRACTION = 0.40;
+
+/** Minimum energy to bother creating a corpse (below this it's not worth tracking). */
+const CORPSE_MIN_ENERGY = 4;
+
+/** Harvest rate from a corpse per frame when a node overlaps (matches food zone rate). */
+const CORPSE_HARVEST_RATE = 0.08;
+
+/**
  * Three-tier food landscape:
  *
  *  Tier 0 — ground (Y=0):  large zones, moderate energy, easy to reach
@@ -21,6 +52,9 @@ export interface EnergyZone {
  */
 export class Environment {
   zones: EnergyZone[] = [];
+
+  /** Decaying energy depots left by dead agents. */
+  corpseDepots: CorpseDepot[] = [];
 
   constructor(
     readonly worldWidth: number,
@@ -84,18 +118,54 @@ export class Environment {
   }
 
   update(dt: number): void {
+    // Replenish food zones
     for (const z of this.zones) {
       z.energy = Math.min(z.maxEnergy, z.energy + z.replenishRate * dt);
+    }
+
+    // Decay corpse depots and remove exhausted ones
+    for (let i = this.corpseDepots.length - 1; i >= 0; i--) {
+      const c = this.corpseDepots[i];
+      c.energy -= c.decayRate * dt;
+      if (c.energy <= 0) {
+        this.corpseDepots.splice(i, 1);
+      }
     }
   }
 
   /**
-   * Attempt to harvest energy from any zone overlapping the given sphere.
+   * Deposit a corpse energy depot at the given world position.
+   * Called by World when an agent dies with meaningful energy remaining.
+   *
+   * @param x  World X position of the corpse centre.
+   * @param y  World Y position (terrain height at that XZ).
+   * @param z  World Z position of the corpse centre.
+   * @param agentEnergy  The agent's energy at the moment of death.
+   */
+  addCorpse(x: number, y: number, z: number, agentEnergy: number): void {
+    const energy = agentEnergy * CORPSE_ENERGY_FRACTION;
+    if (energy < CORPSE_MIN_ENERGY) return;
+
+    this.corpseDepots.push({
+      x,
+      y,
+      z,
+      radius: CORPSE_RADIUS,
+      energy,
+      maxEnergy: energy,
+      decayRate: energy / CORPSE_LIFETIME_S,
+    });
+  }
+
+  /**
+   * Attempt to harvest energy from any food zone overlapping the given sphere.
    * Uses full 3D distance — nodes must be physically near the zone centre
    * (including matching height for elevated zones).
    */
   harvest(x: number, y: number, z: number, radius: number): number {
     let total = 0;
+
+    // Harvest from food zones
     for (const zone of this.zones) {
       const dx = zone.x - x;
       const dy = zone.y - y;
@@ -108,6 +178,21 @@ export class Environment {
         total += take;
       }
     }
+
+    // Harvest from corpse depots
+    for (const depot of this.corpseDepots) {
+      const dx = depot.x - x;
+      const dy = depot.y - y;
+      const dz = depot.z - z;
+      const distSq = dx * dx + dy * dy + dz * dz;
+      const combined = depot.radius + radius;
+      if (distSq < combined * combined) {
+        const take = Math.min(depot.energy, CORPSE_HARVEST_RATE);
+        depot.energy -= take;
+        total += take;
+      }
+    }
+
     return total;
   }
 }

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -246,6 +246,17 @@ export class World {
     return a;
   }
 
+  /**
+   * Deposit a corpse depot for a dying agent if it has meaningful energy.
+   * The corpse is placed at ground level directly below the agent's centre
+   * so that ground-level scavengers can reach it without needing height.
+   */
+  private _depositCorpse(agent: Agent): void {
+    const c = agent.centerPos;
+    const groundY = this.heightfield.heightAt(c.x, c.z);
+    this.env.addCorpse(c.x, groundY, c.z, agent.energy);
+  }
+
   update(dt: number): void {
     this.time += dt;
     this.stepCount++;
@@ -262,8 +273,10 @@ export class World {
     for (const agent of this.agents) {
       if (agent.dead) continue;
 
-      // Max lifespan: forces generational turnover
+      // Max lifespan: forces generational turnover.
+      // Deposit a corpse — old agents may still have significant energy.
       if (agent.age > 180) {
+        this._depositCorpse(agent);
         agent.dead = true;
         liveCount--;
         this.telemetry.recordDeath();
@@ -271,13 +284,16 @@ export class World {
       }
 
       agent.update(dt, this.env.zones, this.worldWidth, this.worldDepth, this.heightfield);
+
+      // Energy-starvation death: agent.energy hit 0 inside update().
+      // Nothing to deposit (energy ≤ 0), but we still record the death.
       if (agent.dead) {
         liveCount--;
         this.telemetry.recordDeath();
         continue;
       }
 
-      // Energy harvesting: each node that overlaps a zone absorbs energy
+      // Energy harvesting: each node that overlaps a zone or corpse absorbs energy
       let frameGained = 0;
       for (const node of agent.nodes) {
         const gained = this.env.harvest(node.pos.x, node.pos.y, node.pos.z, node.radius);


### PR DESCRIPTION
## Summary

- Adds **corpse energy depots** (Phase 1 of Proposal #21): when an agent dies of old age with meaningful energy, a temporary energy depot is left at its position on the terrain surface
- Corpses decay to zero over ~20 seconds with no replenishment, making scavenging a real energy source without flooding the world
- Agents can harvest from corpses via the existing `env.harvest()` path — no change to agent code needed
- Corpses render as dark-red semi-transparent discs that fade as they decay, giving players a clear visual signal of where agents have died

## Changes

- **`src/world/Environment.ts`**: Added `CorpseDepot` interface; added `corpseDepots` array and `addCorpse()` method to `Environment`; extended `update()` to decay and cull spent corpses; extended `harvest()` to include corpse depots alongside food zones
- **`src/world/World.ts`**: Added `_depositCorpse()` helper that places a corpse at terrain height below the dying agent; called on age-death path (where energy may be substantial); starvation deaths (energy ≤ 0) naturally produce no corpse
- **`src/render/Renderer.ts`**: Added `_corpseVisuals` pool; added `_renderCorpses()` method rendering corpses as pooled dark-red `CircleGeometry` discs that scale with depot radius and fade with remaining energy; `_ensureCorpseVisuals()` grows the pool lazily to avoid allocation spikes

## Test plan
- [ ] Run `npm run dev` and verify the simulation starts without errors
- [ ] Observe dark-red discs appearing on the ground after agents die of old age and fading over ~20 seconds
- [ ] Verify agents visibly move toward and linger near corpse discs (scavenging pressure)
- [ ] Confirm no corpse disc appears when an agent starves (energy ≤ 0 at death)
- [ ] Check browser console for runtime errors during normal operation and after population reseeds

Closes #21